### PR TITLE
Increase apigateway.getRestApis from default 25 limit to max (500)

### DIFF
--- a/lambdas/backend/express-route-handlers.js
+++ b/lambdas/backend/express-route-handlers.js
@@ -386,9 +386,8 @@ async function getAdminCatalogVisibility(req, res) {
 
         let visibility = { apiGateway: [] },
             catalogObject = await catalog(),
-            apis = (await exports.apigateway.getRestApis().promise()).items
+            apis = (await exports.apigateway.getRestApis({limit: 500}).promise()).items
 
-        console.log(`network request: ${JSON.stringify(apis, null, 4)}`)
         console.log(`apis: ${JSON.stringify(apis, null, 4)}`)
 
         let promises = []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  Fixes missing apis in admin view.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
